### PR TITLE
Implement Submotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.5.0
 
+* Added Submotions, requiring a one-third consensus to pass.
+* Added a Discord command `$submotion` for calling Submotions.
 * Added subcommands: `bot`, `web`, `worker`, and `fix_transactions`
 * Removed env mode flags
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "*"
 regex = "1"
 chrono = "*"
 chrono-tz = "*"
-bigdecimal = "=0.1.2"
+bigdecimal = { version = "=0.1.2", features = ["serde"] }
 maplit = "1.0.2"
 ordinal = "*"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -67,15 +67,17 @@ $b
 
 Shows you how many generators and how much capital you have. Remember, except for motions the bot always responds in the same channel it receives the message in, so if you wish to keep your balances private, always run this command in DMs.
 
-### Motion/Supermotion
+### Motion/Supermotion/Submotion
 
 ```text
 $motion <your text here>
 
 $supermotion <your text here>
+
+$submotion <your text here>
 ```
 
-Calls a motion to be voted on. If `$motion` is used, the motion requires a simple majority for the bot to declare it as "passed". If `$supermotion` is used, the motion requires a supermajority, or greater than 2/3rds vote. According to the doc, any motion that "Changes to the core system, including: vote costs, bot behaviour, and creation and distribution of additional gens" must be passed with a 2/3rds vote, ie. with `$supermotion`
+Calls a motion to be voted on. If `$motion` is used, the motion requires a simple majority for the bot to declare it as "passed". If `$supermotion` is used, the motion requires a supermajority, or greater than two-thirds vote. If `$submotion` is used, the motion requires only a one-third submajority. According to the doc, any motion that "Changes to the core system, including: vote costs, bot behaviour, and creation and distribution of additional gens" must be passed with a 2/3rds vote, ie. with `$supermotion`
 
 ### Vote
 

--- a/migrations/2022-06-06-202235_submotions/down.sql
+++ b/migrations/2022-06-06-202235_submotions/down.sql
@@ -1,0 +1,6 @@
+alter table motions add column is_super boolean not null default false;
+
+update motions set is_super = false where power = 1;
+update motions set is_super = true where power = 2;
+
+alter table motions drop column power;

--- a/migrations/2022-06-06-202235_submotions/up.sql
+++ b/migrations/2022-06-06-202235_submotions/up.sql
@@ -1,0 +1,6 @@
+alter table motions add column power numeric not null default 0;
+
+update motions set power = 1 where is_super = false;
+update motions set power = 2 where is_super = true;
+
+alter table motions drop column is_super;

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -88,17 +88,17 @@ lazy_static! {
 
 pub const VOTE_BASE_COST:u16 = 40;
 #[cfg(not(feature = "debug"))]
-pub const MOTIONS_CHANNEL:u64 = 983019887024807976; //bureaucracy channel
+pub const MOTIONS_CHANNEL:u64 = 609093491150028800; //bureaucracy channel
 #[cfg(feature = "debug")]
 //const MOTIONS_CHANNEL:u64 = 694013828362534983; //pluto-dev channel
 //const MOTIONS_CHANNEL:u64 = 610387757818183690; //test channel in shelvacuisawesomeserver
 //const MOTIONS_CHANNEL:u64 = 560918427091468387; //spam channel
-pub const MOTIONS_CHANNEL:u64 = 983019887024807976; //pluto-beta-messages in CONceptualization
+pub const MOTIONS_CHANNEL:u64 = 770726979456466954; //pluto-beta-messages in CONceptualization
 
 #[cfg(not(feature = "debug"))]
-pub const MY_ID_INT:u64 = 415006970605731844;
+pub const MY_ID_INT:u64 = 690112509537288202;
 #[cfg(feature = "debug")]
-pub const MY_ID_INT:u64 = 415006970605731844;
+pub const MY_ID_INT:u64 = 698996983305863178;
 
 pub const MY_ID:SerenityUserId = SerenityUserId(MY_ID_INT);
 

--- a/src/is_win.rs
+++ b/src/is_win.rs
@@ -1,39 +1,30 @@
-pub fn is_win(yes_votes:i64, no_votes:i64, is_super:bool) -> bool {
-    if is_super {
-        (yes_votes/2, yes_votes%2) > (no_votes, 0)
-    } else {
-        yes_votes > no_votes
-    }
+use bigdecimal::BigDecimal;
+
+pub fn is_win(yes_votes: i64, no_votes: i64, power: &BigDecimal) -> bool {
+    BigDecimal::from(no_votes) * power >= BigDecimal::from(yes_votes)
 }
 
 #[cfg(test)]
 mod test {
-    fn old_is_win(yes_votes:i64, no_votes:i64, is_super:bool) -> bool {
-        if is_super {
-            let total = yes_votes + no_votes;
-            let div = total / 3;
-            let rem = total % 3;
-            // 10 = 3 rem 1
-            // win is >= 7 (div*2+rem)
-            // 11 = 3 rem 2
-            // win is >= 7 (div*2+rem)
-            // 12 = 4 rem 0
-            // 8 is a "tie", so lose
-            // win is >= 9 (div*2+rem)+1
-            let winning_amount = (div*2+rem) + if rem == 0 {1} else {0};
-            yes_votes >= winning_amount
-        }else{
-            yes_votes > no_votes
-        }
-    }
-
     #[test]
-    fn wins_match(){
+    fn does_win(){
         use super::is_win;
-        assert_eq!(old_is_win(1, 0, false), is_win(1, 0, false));
-        assert_eq!(old_is_win(1, 1, false), is_win(1, 1, false));
-        assert_eq!(old_is_win(1, 2, false), is_win(1, 2, false));
-        assert_eq!(old_is_win(2, 1, true),  is_win(2, 1, true));
-        assert_eq!(old_is_win(3, 1, true),  is_win(3, 1, true));
+        use bigdecimal::BigDecimal;
+        let one = BigDecimal::from(1);
+        let two = BigDecimal::from(2);
+        let half = BigDecimal::from(0.5);
+        let thirdish = BigDecimal::from(0.3333333333);
+        let tenth = BigDecimal::from(0.1);
+        assert_eq!(is_win(1, 0, &one), true);
+        assert_eq!(is_win(1, 1, &one), false);
+        assert_eq!(is_win(1, 2, &one), false);
+        assert_eq!(is_win(2, 1, &one), true);
+        assert_eq!(is_win(2, 1, &two), false);
+        assert_eq!(is_win(3, 1, &two), true);
+        assert_eq!(is_win(1, 1, &half), true);
+        assert_eq!(is_win(1, 3, &third), true);
+        assert_eq!(is_win(1000, 10, &tenth), false);
+        assert_eq!(is_win(1001, 10, &tenth), true);
+        assert_eq!(is_win(1000, 500, &one), false);
     }
 }

--- a/src/is_win.rs
+++ b/src/is_win.rs
@@ -22,9 +22,8 @@ mod test {
         assert_eq!(is_win(2, 1, &two), false);
         assert_eq!(is_win(3, 1, &two), true);
         assert_eq!(is_win(1, 1, &half), true);
-        assert_eq!(is_win(1, 3, &third), true);
-        assert_eq!(is_win(1000, 10, &tenth), false);
-        assert_eq!(is_win(1001, 10, &tenth), true);
-        assert_eq!(is_win(1000, 500, &one), false);
+        assert_eq!(is_win(1, 3, &thirdish), true);
+        assert_eq!(is_win(100, 1000, &tenth), false);
+        assert_eq!(is_win(101, 1000, &tenth), true);
     }
 }

--- a/src/is_win.rs
+++ b/src/is_win.rs
@@ -1,7 +1,7 @@
 use bigdecimal::BigDecimal;
 
 pub fn is_win(yes_votes: i64, no_votes: i64, power: &BigDecimal) -> bool {
-    BigDecimal::from(no_votes) * power >= BigDecimal::from(yes_votes)
+    BigDecimal::from(no_votes) * power < BigDecimal::from(yes_votes)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod view_schema;
 mod damm;
 mod bot;
 mod is_win;
+mod motion_label;
 mod worker;
 mod tasks;
 mod fix_transactions;

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,6 +7,7 @@ use diesel::sql_types::Int8;
 use diesel::deserialize;
 use diesel::serialize;
 use diesel_derive_enum::DbEnum;
+use bigdecimal::BigDecimal;
 use crate::transfers::CurrencyId;
 
 // Thanks to Chayum Friedman https://stackoverflow.com/a/69877842/1267729
@@ -140,7 +141,7 @@ pub struct Motion<'a> {
     pub motion_text:Cow<'a, str>,
     pub motioned_at:DateTime<Utc>,
     pub last_result_change:DateTime<Utc>,
-    pub is_super:bool,
+    pub power:BigDecimal,
     pub announcement_message_id:Option<i64>,
 }
 
@@ -151,7 +152,7 @@ pub struct MotionWithCount<'a> {
     pub motion_text:Cow<'a, str>,
     pub motioned_at:DateTime<Utc>,
     pub last_result_change:DateTime<Utc>,
-    pub is_super:bool,
+    pub power:BigDecimal,
     pub announcement_message_id:Option<i64>,
     pub yes_vote_count:u64,
     pub no_vote_count:u64,
@@ -171,24 +172,25 @@ impl<'a> Motion<'a> {
         motion_text,
         motioned_at,
         last_result_change,
-        is_super,
+        power,
         announcement_message_id,
     }
 }
 
 impl<'a> MotionWithCount<'a>{
     pub fn from_motion(m: Motion, yes_vote_count: u64, no_vote_count: u64) -> MotionWithCount {
-        MotionWithCount{
+        let outcome = crate::is_win::is_win(yes_vote_count as i64, no_vote_count as i64, &m.power);
+        MotionWithCount {
             rowid: m.rowid,
             bot_message_id: m.bot_message_id,
             motion_text: m.motion_text,
             motioned_at: m.motioned_at,
             last_result_change: m.last_result_change,
-            is_super: m.is_super,
+            power: m.power,
             announcement_message_id: m.announcement_message_id,
             yes_vote_count,
             no_vote_count,
-            is_win: crate::is_win::is_win(yes_vote_count as i64, no_vote_count as i64, m.is_super),
+            is_win: outcome,
         }
     }
 

--- a/src/motion_label.rs
+++ b/src/motion_label.rs
@@ -1,0 +1,11 @@
+use bigdecimal::BigDecimal;
+use std::cmp::Ordering;
+
+pub fn motion_label(power: &BigDecimal) -> String {
+  let one = BigDecimal::from(1);
+  match power.cmp(&one) {
+    Ordering::Greater => String::from("Supermotion"),
+    Ordering::Less => String::from("Submotion"),
+    Ordering::Equal => String::from("Simple motion"),
+  }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -62,10 +62,10 @@ table! {
         motion_text -> Text,
         motioned_at -> Timestamptz,
         last_result_change -> Timestamptz,
-        is_super -> Bool,
         announcement_message_id -> Nullable<Int8>,
         needs_update -> Bool,
         motioned_by -> Int8,
+        power -> Numeric,
     }
 }
 

--- a/src/web/debug_utils.rs
+++ b/src/web/debug_utils.rs
@@ -218,9 +218,9 @@ pub fn debug_util_forms(
             form action="/debug_util/make_motion" method="get" {
                 "Make "
                 select name="power" {
+                    option value="0.5" { "sub" }
                     option value="1" { "simple" }
                     option value="2" { "super" }
-                    option value="0.5" { "sub" }
                 }
                 " motion called by "
                 input type="number" name="called_by";

--- a/src/web/debug_utils.rs
+++ b/src/web/debug_utils.rs
@@ -137,14 +137,16 @@ pub fn make_auction(
     Ok(Redirect::to(uri))
 }
 
-#[get("/debug_util/make_motion?<is_super>&<content>&<called_by>")]
+#[get("/debug_util/make_motion?<power>&<content>&<called_by>")]
 pub fn make_motion(
     ctx: CommonContext,
-    is_super: bool,
+    power: String,
     content: String,
     called_by: i64,
 ) -> Result<Redirect, template::ErrorResponse> {
+    use bigdecimal::BigDecimal;
     let now = Utc::now();
+    let power_bigd: BigDecimal = power.parse().unwrap();
     if called_by < 0 {
         return hard_err(Status::BadRequest);
     }
@@ -164,7 +166,7 @@ pub fn make_motion(
         mdsl::motion_text.eq(content),
         mdsl::motioned_at.eq(now),
         mdsl::last_result_change.eq(now),
-        mdsl::is_super.eq(is_super),
+        mdsl::power.eq(power_bigd),
         mdsl::motioned_by.eq(called_by),
     )).execute(&*ctx).unwrap();
 
@@ -215,9 +217,10 @@ pub fn debug_util_forms(
             br;br;
             form action="/debug_util/make_motion" method="get" {
                 "Make "
-                select name="is_super" {
-                    option value="false" { "simple" }
-                    option value="true" { "super" }
+                select name="power" {
+                    option value="1" { "simple" }
+                    option value="2" { "super" }
+                    option value="0.5" { "sub" }
                 }
                 " motion called by "
                 input type="number" name="called_by";

--- a/src/web/motions.rs
+++ b/src/web/motions.rs
@@ -4,6 +4,7 @@ use rocket::request::{FromQuery, Query};
 
 use super::prelude::*;
 use crate::models::{Motion,MotionWithCount,MotionVote,Transfer,TransferExtra};
+use crate::motion_label::motion_label;
 
 #[derive(Debug, Clone, FromForm)]
 pub struct VoteForm {
@@ -97,11 +98,7 @@ fn motion_meta_description(
 
     let motion_text = format!(
         "{} {}",
-        if motion.is_super {
-            "Super motion"
-        } else {
-            "Simple motion"
-        },
+        motion_label(&motion.power),
         motion.motion_text
     );
 
@@ -139,6 +136,7 @@ fn motion_meta_description(
 fn motion_snippet(
     motion: &crate::models::MotionWithCount
 ) -> maud::Markup {
+    let cap_label = motion_label(&motion.power);
     maud::html!{
         div.motion-titlebar {
             a href=(format!("/motions/{}", motion.damm_id())) {
@@ -167,11 +165,8 @@ fn motion_snippet(
             }
         }
         p {
-            @if motion.is_super {
-                "Super motion "
-            } @else {
-                "Simple motion "
-            }
+            (cap_label)
+            " "
             (motion.motion_text)
         }
         div {


### PR DESCRIPTION
- Replaced the `is_super` boolean with a `power` numeric in the `motions` table.
  - Converted simple motions to `1` and supermotions to `2`.
- Set the `serde` feature flag on the `bigdecimal` library to allow serialization.
- Added Submotions, requiring a one-third consensus to pass.
  - Submotions are stored with a power level of `0.5`.
  - Added a Discord command $submotion for calling Submotions.
  - Updated the debugging web interface to include Submotions.